### PR TITLE
CI: enable `dune-cache`

### DIFF
--- a/.github/workflows/ocaml-ci.yml
+++ b/.github/workflows/ocaml-ci.yml
@@ -22,6 +22,7 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: ${{ matrix.os != 'windows-latest' }}
 
       - run: opam install . --deps-only --with-test
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -22,6 +22,7 @@ jobs:
       uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
+        dune-cache: true # since running on ubuntu
     - run: opam install . --deps-only --with-test
     - run: opam exec -- dune build
     - run: opam exec -- cargo fmt --all -- --check


### PR DESCRIPTION
I don't think this will cut down on all of the CI build time issues (esp. since much of it is the tooling to build the compiler itself), but this should help. Only concern is if the cache has issues re: bumping versions of RSDD, but I'll keep that in mind (and revert this when necessary).